### PR TITLE
Add basic PeerJS demo component

### DIFF
--- a/apps/the-circle-frontend/src/app/app.component.html
+++ b/apps/the-circle-frontend/src/app/app.component.html
@@ -6,6 +6,7 @@
 <!-- <avans-nx-workshop-breadcrumb></avans-nx-workshop-breadcrumb> -->
 <!--  -->
 <div class="mx-auto w-full max-w-screen-xl p-4 py-6 lg:py-8">
+    <avans-peer-demo></avans-peer-demo>
     <router-outlet></router-outlet>
 </div>
 <!--  -->

--- a/apps/the-circle-frontend/src/app/app.component.ts
+++ b/apps/the-circle-frontend/src/app/app.component.ts
@@ -2,10 +2,11 @@ import { Component } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { initFlowbite } from 'flowbite';
 import { Router, RouterModule } from '@angular/router';
+import { PeerDemoComponent } from './webrtc/peer-demo.component';
 
 @Component({
     standalone: true,
-    imports: [RouterModule],
+    imports: [RouterModule, PeerDemoComponent],
     selector: 'avans-nx-workshop-root',
     templateUrl: './app.component.html'
 })

--- a/apps/the-circle-frontend/src/app/webrtc/peer-demo.component.ts
+++ b/apps/the-circle-frontend/src/app/webrtc/peer-demo.component.ts
@@ -1,0 +1,47 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PeerService } from './peer.service';
+
+@Component({
+  selector: 'avans-peer-demo',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="flex flex-col gap-2">
+      <div>My ID: {{ peerId }}</div>
+      <div class="flex gap-2">
+        <video #localVideo autoplay playsinline muted class="w-40 h-32 bg-black"></video>
+        <video #remoteVideo autoplay playsinline class="w-40 h-32 bg-black"></video>
+      </div>
+      <div class="flex gap-2 items-center">
+        <input #remoteIdInput type="text" placeholder="Remote ID" class="border p-1" />
+        <button (click)="startCall(remoteIdInput.value)" class="border px-2">Call</button>
+      </div>
+    </div>
+  `
+})
+export class PeerDemoComponent implements OnInit {
+  @ViewChild('localVideo', { static: true }) localVideo!: ElementRef<HTMLVideoElement>;
+  @ViewChild('remoteVideo', { static: true }) remoteVideo!: ElementRef<HTMLVideoElement>;
+
+  peerId = '';
+
+  constructor(private readonly peerService: PeerService) {}
+
+  async ngOnInit(): Promise<void> {
+    const localStream = await this.peerService.getLocalStream();
+    this.localVideo.nativeElement.srcObject = localStream;
+
+    this.peerService.onOpen(id => (this.peerId = id));
+    this.peerService.listen(localStream, stream => {
+      this.remoteVideo.nativeElement.srcObject = stream;
+    });
+  }
+
+  async startCall(id: string): Promise<void> {
+    const localStream = await this.peerService.getLocalStream();
+    this.peerService.call(id, localStream).on('stream', stream => {
+      this.remoteVideo.nativeElement.srcObject = stream;
+    });
+  }
+}

--- a/apps/the-circle-frontend/src/app/webrtc/peer.service.ts
+++ b/apps/the-circle-frontend/src/app/webrtc/peer.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import Peer, { MediaConnection } from 'peerjs';
+
+@Injectable({ providedIn: 'root' })
+export class PeerService {
+  private peer?: Peer;
+  private activeCall?: MediaConnection;
+
+  private ensurePeer(): Peer {
+    if (!this.peer) {
+      this.peer = new Peer(undefined, {
+        host: 'localhost',
+        port: 9000,
+        path: '/'
+      });
+    }
+    return this.peer;
+  }
+
+  async getLocalStream(): Promise<MediaStream> {
+    return navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+  }
+
+  call(remoteId: string, stream: MediaStream): MediaConnection {
+    const peer = this.ensurePeer();
+    const call = peer.call(remoteId, stream);
+    this.activeCall = call;
+    return call;
+  }
+
+  listen(stream: MediaStream, onRemoteStream: (remote: MediaStream) => void): void {
+    const peer = this.ensurePeer();
+    peer.on('call', call => {
+      this.activeCall = call;
+      call.answer(stream);
+      call.on('stream', onRemoteStream);
+    });
+  }
+
+  onOpen(callback: (id: string) => void): void {
+    this.ensurePeer().on('open', callback);
+  }
+}


### PR DESCRIPTION
## Summary
- create PeerService and PeerDemoComponent
- show PeerDemoComponent on front page
- integrate PeerJS as small demo to start WebRTC stream

## Testing
- `npm install`
- `npm test` *(fails: could not find module 'mongodb-memory-server' in users:test)*

------
https://chatgpt.com/codex/tasks/task_e_684ff76f5a88832f85421a984b18a4f3