### PR TITLE
Add basic PeerJS demo component

### DIFF
--- a/apps/the-circle-frontend/src/app/app.component.html
+++ b/apps/the-circle-frontend/src/app/app.component.html
@@ -6,6 +6,7 @@
 <!-- <avans-nx-workshop-breadcrumb></avans-nx-workshop-breadcrumb> -->
 <!--  -->
 <div class="mx-auto w-full max-w-screen-xl p-4 py-6 lg:py-8">
+    <avans-peer-demo></avans-peer-demo>
     <router-outlet></router-outlet>
 </div>
 <!--  -->

--- a/apps/the-circle-frontend/src/app/app.component.ts
+++ b/apps/the-circle-frontend/src/app/app.component.ts
@@ -2,10 +2,11 @@ import { Component } from '@angular/core';
 import { OnInit } from '@angular/core';
 import { initFlowbite } from 'flowbite';
 import { Router, RouterModule } from '@angular/router';
+import { PeerDemoComponent } from './webrtc/peer-demo.component';
 
 @Component({
     standalone: true,
-    imports: [RouterModule],
+    imports: [RouterModule, PeerDemoComponent],
     selector: 'avans-nx-workshop-root',
     templateUrl: './app.component.html'
 })

--- a/apps/the-circle-frontend/src/app/webrtc/peer-demo.component.ts
+++ b/apps/the-circle-frontend/src/app/webrtc/peer-demo.component.ts
@@ -1,0 +1,47 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PeerService } from './peer.service';
+
+@Component({
+  selector: 'avans-peer-demo',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div class="flex flex-col gap-2">
+      <div>My ID: {{ peerId }}</div>
+      <div class="flex gap-2">
+        <video #localVideo autoplay playsinline muted class="w-40 h-32 bg-black"></video>
+        <video #remoteVideo autoplay playsinline class="w-40 h-32 bg-black"></video>
+      </div>
+      <div class="flex gap-2 items-center">
+        <input #remoteIdInput type="text" placeholder="Remote ID" class="border p-1" />
+        <button (click)="startCall(remoteIdInput.value)" class="border px-2">Call</button>
+      </div>
+    </div>
+  `
+})
+export class PeerDemoComponent implements OnInit {
+  @ViewChild('localVideo', { static: true }) localVideo!: ElementRef<HTMLVideoElement>;
+  @ViewChild('remoteVideo', { static: true }) remoteVideo!: ElementRef<HTMLVideoElement>;
+
+  peerId = '';
+
+  constructor(private readonly peerService: PeerService) {}
+
+  async ngOnInit(): Promise<void> {
+    const localStream = await this.peerService.getLocalStream();
+    this.localVideo.nativeElement.srcObject = localStream;
+
+    this.peerService.onOpen(id => (this.peerId = id));
+    this.peerService.listen(localStream, stream => {
+      this.remoteVideo.nativeElement.srcObject = stream;
+    });
+  }
+
+  async startCall(id: string): Promise<void> {
+    const localStream = await this.peerService.getLocalStream();
+    this.peerService.call(id, localStream).on('stream', stream => {
+      this.remoteVideo.nativeElement.srcObject = stream;
+    });
+  }
+}

--- a/apps/the-circle-frontend/src/app/webrtc/peer.service.ts
+++ b/apps/the-circle-frontend/src/app/webrtc/peer.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import Peer, { MediaConnection } from 'peerjs';
+import { environment } from '@avans-nx-workshop/shared/util-env';
 
 @Injectable({ providedIn: 'root' })
 export class PeerService {
@@ -9,8 +10,8 @@ export class PeerService {
   private ensurePeer(): Peer {
     if (!this.peer) {
       this.peer = new Peer(undefined, {
-        host: 'localhost',
-        port: 9000,
+        host: environment.PEER_SERVER_HOST,
+        port: environment.PEER_SERVER_PORT,
         path: '/'
       });
     }

--- a/apps/the-circle-frontend/src/app/webrtc/peer.service.ts
+++ b/apps/the-circle-frontend/src/app/webrtc/peer.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from '@angular/core';
+import Peer, { MediaConnection } from 'peerjs';
+
+@Injectable({ providedIn: 'root' })
+export class PeerService {
+  private peer?: Peer;
+  private activeCall?: MediaConnection;
+
+  private ensurePeer(): Peer {
+    if (!this.peer) {
+      this.peer = new Peer(undefined, {
+        host: 'localhost',
+        port: 9000,
+        path: '/'
+      });
+    }
+    return this.peer;
+  }
+
+  async getLocalStream(): Promise<MediaStream> {
+    return navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+  }
+
+  call(remoteId: string, stream: MediaStream): MediaConnection {
+    const peer = this.ensurePeer();
+    const call = peer.call(remoteId, stream);
+    this.activeCall = call;
+    return call;
+  }
+
+  listen(stream: MediaStream, onRemoteStream: (remote: MediaStream) => void): void {
+    const peer = this.ensurePeer();
+    peer.on('call', call => {
+      this.activeCall = call;
+      call.answer(stream);
+      call.on('stream', onRemoteStream);
+    });
+  }
+
+  onOpen(callback: (id: string) => void): void {
+    this.ensurePeer().on('open', callback);
+  }
+}

--- a/libs/shared/util-env/src/lib/environment.development.ts
+++ b/libs/shared/util-env/src/lib/environment.development.ts
@@ -6,5 +6,8 @@ export const environment: IEnvironment = {
     ROOT_DOMAIN_URL: 'http://localhost:3000',
     dataApiUrl: 'http://localhost:3000/api',
 
-    MONGO_DB_CONNECTION_STRING: 'mongodb://localhost:27017/shareameal'
+    MONGO_DB_CONNECTION_STRING: 'mongodb://localhost:27017/shareameal',
+
+    PEER_SERVER_HOST: 'localhost',
+    PEER_SERVER_PORT: 9000
 };

--- a/libs/shared/util-env/src/lib/environment.interface.ts
+++ b/libs/shared/util-env/src/lib/environment.interface.ts
@@ -8,4 +8,10 @@ export interface IEnvironment {
 
     // Hier kun je meer environment
     // variabelen zetten als dat nodig is
+
+    /** Hostname van de PeerJS-signaling server */
+    PEER_SERVER_HOST: string;
+
+    /** Poort van de PeerJS-signaling server */
+    PEER_SERVER_PORT: number;
 }

--- a/libs/shared/util-env/src/lib/environment.production.ts
+++ b/libs/shared/util-env/src/lib/environment.production.ts
@@ -6,5 +6,8 @@ export const environment: IEnvironment = {
     ROOT_DOMAIN_URL: 'https://nxworkshop.azurewebsites.net',
     dataApiUrl: 'https://nxworkshop.azurewebsites.net/api',
 
-    MONGO_DB_CONNECTION_STRING: 'mongodb://remote-host/mongodb'
+    MONGO_DB_CONNECTION_STRING: 'mongodb://remote-host/mongodb',
+
+    PEER_SERVER_HOST: 'nxworkshop.azurewebsites.net',
+    PEER_SERVER_PORT: 9000
 };

--- a/libs/shared/util-env/src/lib/environment.ts
+++ b/libs/shared/util-env/src/lib/environment.ts
@@ -6,5 +6,8 @@ export const environment: IEnvironment = {
     ROOT_DOMAIN_URL: 'dummy',
     dataApiUrl: 'dummy',
 
-    MONGO_DB_CONNECTION_STRING: 'dummy'
+    MONGO_DB_CONNECTION_STRING: 'dummy',
+
+    PEER_SERVER_HOST: 'localhost',
+    PEER_SERVER_PORT: 9000
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
                 "passport": "^0.6.0",
                 "passport-jwt": "^4.0.1",
                 "passport-local": "^1.0.0",
+                "peerjs": "^1.5.5",
                 "popper.js": "^1.16.1",
                 "reflect-metadata": "^0.1.13",
                 "rxjs": "~7.8.0",
@@ -5231,6 +5232,15 @@
             "integrity": "sha512-t7c5K033joZZMspnHg/gWPE4kandgc2OxE74aYOtGKfgB9VPuVJPix0H6fhmm2erj5PBJ21mqcx34lpIGtUCsQ==",
             "dependencies": {
                 "sparse-bitfield": "^3.0.3"
+            }
+        },
+        "node_modules/@msgpack/msgpack": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/@msgpack/msgpack/-/msgpack-2.8.0.tgz",
+            "integrity": "sha512-h9u4u/jiIRKbq25PM+zymTyW6bhTzELvOoUd+AvYriWOAKpLGnIamaET3pnHYoI5iYphAHBI4ayx0MehR+VVPQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/@nestjs/common": {
@@ -17276,6 +17286,38 @@
             "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
             "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
         },
+        "node_modules/peerjs": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/peerjs/-/peerjs-1.5.5.tgz",
+            "integrity": "sha512-viMUCPDL6CSfOu0ZqVcFqbWRXNHIbv2lPqNbrBIjbFYrflebOjItJ4hPfhjnuUCstqciHVu9vVJ7jFqqKi/EuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@msgpack/msgpack": "^2.8.0",
+                "eventemitter3": "^4.0.7",
+                "peerjs-js-binarypack": "^2.1.0",
+                "webrtc-adapter": "^9.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/peer"
+            }
+        },
+        "node_modules/peerjs-js-binarypack": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/peerjs-js-binarypack/-/peerjs-js-binarypack-2.1.0.tgz",
+            "integrity": "sha512-YIwCC+pTzp3Bi8jPI9UFKO0t0SLo6xALnHkiNt/iUFmUUZG0fEEmEyFKvjsDKweiFitzHRyhuh6NvyJZ4nNxMg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/peer"
+            }
+        },
         "node_modules/pend": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -18797,6 +18839,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
             }
+        },
+        "node_modules/sdp": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.1.tgz",
+            "integrity": "sha512-lwsAIzOPlH8/7IIjjz3K0zYBk7aBVVcvjMwt3M4fLxpjMYyy7i3I97SLHebgn4YBjirkzfp3RvRDWSKsh/+WFw==",
+            "license": "MIT"
         },
         "node_modules/secure-compare": {
             "version": "3.0.1",
@@ -21637,6 +21685,19 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/webrtc-adapter": {
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.3.tgz",
+            "integrity": "sha512-5fALBcroIl31OeXAdd1YUntxiZl1eHlZZWzNg3U4Fn+J9/cGL3eT80YlrsWGvj2ojuz1rZr2OXkgCzIxAZ7vRQ==",
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "sdp": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=6.0.0",
+                "npm": ">=3.10.0"
             }
         },
         "node_modules/websocket-driver": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "passport": "^0.6.0",
         "passport-jwt": "^4.0.1",
         "passport-local": "^1.0.0",
+        "peerjs": "^1.5.5",
         "popper.js": "^1.16.1",
         "reflect-metadata": "^0.1.13",
         "rxjs": "~7.8.0",


### PR DESCRIPTION
## Summary
- create PeerService and PeerDemoComponent
- show PeerDemoComponent on front page
- integrate PeerJS as small demo to start WebRTC stream

## Testing
- `npm install`
- `npm test` *(fails: could not find module 'mongodb-memory-server' in users:test)*

------
https://chatgpt.com/codex/tasks/task_e_684ff76f5a88832f85421a984b18a4f3